### PR TITLE
Daisy chain TensorMap parents to learn trees

### DIFF
--- a/ml4cvd/models.py
+++ b/ml4cvd/models.py
@@ -428,7 +428,7 @@ def make_multimodal_multitask_model(tensor_maps_in: List[TensorMap] = None,
             conv_label = conv_layer(tm.shape[channel_axis], _one_by_n_kernel(len(tm.shape)), activation="linear")(last_conv)
             output_predictions[tm.output_name()] = Activation(tm.activation, name=tm.output_name())(conv_label)
         elif tm.parents is not None:
-            parented_activation = concatenate([multimodal_activation] + [output_predictions[p] for p in tm.parents])
+            parented_activation = concatenate([multimodal_activation] + [output_predictions[p.output_name()] for p in tm.parents])
             parented_activation = _dense_layer(parented_activation, layers, tm.annotation_units, activation, conv_normalize)
             output_predictions[tm.output_name()] = Dense(units=tm.shape[0], activation=tm.activation, name=tm.output_name())(parented_activation)
         elif tm.is_categorical_any():

--- a/ml4cvd/tensor_from_file.py
+++ b/ml4cvd/tensor_from_file.py
@@ -742,14 +742,7 @@ TMAPS['lv_mass_dubois_index_sentinel'] = TensorMap('lv_mass_dubois_index', group
 TMAPS['lv_mass_mosteller_index_sentinel'] = TensorMap('lv_mass_mosteller_index', group='continuous', activation='linear', sentinel=0, loss_weight=1.0,
                                                       tensor_from_file=_make_index_tensor_from_file('bsa_mosteller'),
                                                       channel_map={'lv_mass': 0}, normalization={'mean': 89.7, 'std': 24.8})
-TMAPS['lv_mass_dubois_indexp'] = TensorMap('lv_mass_dubois_index', group='continuous', activation='linear', loss='logcosh', loss_weight=1.0,
-                                           parents=['output_mri_systole_diastole_8_segmented_categorical'],
-                                           tensor_from_file=_make_index_tensor_from_file('bsa_dubois'),
-                                           channel_map={'lv_mass': 0}, normalization={'mean': 89.7, 'std': 24.8})
-TMAPS['lv_mass_mosteller_indexp'] = TensorMap('lv_mass_mosteller_index', group='continuous', activation='linear', loss='logcosh', loss_weight=1.0,
-                                              parents=['output_mri_systole_diastole_8_segmented_categorical'],
-                                              tensor_from_file=_make_index_tensor_from_file('bsa_mosteller'),
-                                              channel_map={'lv_mass': 0}, normalization={'mean': 89.7, 'std': 24.8})
+
 TMAPS['lvm_dubois_index'] = TensorMap('lvm_dubois_index', group='continuous', activation='linear', loss='logcosh', loss_weight=1.0,
                                       tensor_from_file=_make_index_tensor_from_file('bsa_dubois'),
                                       channel_map={'LVM': 0}, normalization={'mean': 89.7, 'std': 24.8})

--- a/ml4cvd/tensor_maps_by_hand.py
+++ b/ml4cvd/tensor_maps_by_hand.py
@@ -132,10 +132,10 @@ TMAPS['charge'] = TensorMap('charge', group='continuous', channel_map={'charge':
                             validator=make_range_validator(0, 20))
 
 TMAPS['qtc-intervalp'] = TensorMap('QTCInterval', group='continuous', channel_map={'QTCInterval': 0}, loss='logcosh', validator=make_range_validator(100, 900),
-                                  parents=['output_QTInterval_continuous', 'output_RRInterval_continuous'], normalization={'mean': 419.1, 'std': 20.7})
+                                  parents=[TMAPS['qt-interval'], TMAPS['rr-interval']], normalization={'mean': 419.1, 'std': 20.7})
 TMAPS['qrs-durationpp'] = TensorMap('QRSDuration', group='continuous', channel_map={'QRSDuration': 0}, loss='logcosh', validator=make_range_validator(45, 175),
                                     normalization={'mean': 89.53, 'std': 12.21},
-                                    parents=['output_QTCInterval_continuous'])
+                                    parents=[TMAPS['qtc-intervalp']])
 
 TMAPS['p-axis-sentinel'] = TensorMap('PAxis', group='continuous', channel_map={'PAxis': 0}, sentinel=0, metrics=['logcosh'],
                                      normalization={'mean': 48.7, 'std': 23.1})
@@ -157,10 +157,10 @@ TMAPS['qtc-interval-sentinel'] = TensorMap('QTCInterval', group='continuous', ch
                                            normalization={'mean': 419.1, 'std': 20.7})
 TMAPS['qtc-intervalp-sentinel'] = TensorMap('QTCInterval', group='continuous', channel_map={'QTCInterval': 0}, sentinel=0,
                                             normalization={'mean': 419.1, 'std': 20.7},
-                                            parents=['output_QTInterval_continuous', 'output_RRInterval_continuous'])
+                                            parents=[TMAPS['qt-interval'], TMAPS['rr-interval']])
 TMAPS['qtc-intervalp-sentinel'] = TensorMap('QTCInterval', group='continuous', channel_map={'QTCInterval': 0}, sentinel=0,
                                             normalization={'mean': 419.1, 'std': 20.7},
-                                            parents=['output_QTInterval_continuous', 'output_RRInterval_continuous'])
+                                            parents=[TMAPS['qt-interval'], TMAPS['rr-interval']])
 TMAPS['r-axis-sentinel'] = TensorMap('RAxis', group='continuous', channel_map={'RAxis': 0}, sentinel=0, normalization={'mean': 25.7, 'std': 36.6})
 TMAPS['rr-interval-sentinel'] = TensorMap('RRInterval', group='continuous', channel_map={'RRInterval': 0}, sentinel=0,
                                           normalization={'mean': 1040.61, 'std': 175.5})
@@ -274,9 +274,6 @@ TMAPS['lvm_mosteller_index_prediction_sentinel'] = TensorMap('lvm_mosteller_inde
                                                              sentinel=0, channel_map={'lvm_mosteller_index_sentinel_prediction': 0},
                                                              normalization={'mean': 89.7, 'std': 24.8})
 
-TMAPS['lv_massp'] = TensorMap('lv_mass', group='continuous', activation='linear', loss='logcosh',
-                              parents=['output_mri_systole_diastole_8_segmented_categorical'],
-                              channel_map={'lv_mass': 0}, normalization={'mean': 89.7, 'std': 24.8})
 
 
 TMAPS['end_systole_volume'] = TensorMap('end_systole_volume', group='continuous', activation='linear', validator=make_range_validator(0, 300),
@@ -393,24 +390,23 @@ TMAPS['sax_pixel_height'] = TensorMap('mri_pixel_height_segmented_sax_inlinevf',
 TMAPS['end_systole_volumep'] = TensorMap('end_systole_volume', group='continuous', activation='linear',
                                      loss='logcosh', channel_map={'end_systole_volume': 0},
                                      normalization={'mean': 47.0, 'std': 10.0},
-                                     parents=['output_' + MRI_SEGMENTED + '_categorical'])
+                                     parents=[TMAPS[MRI_SEGMENTED]])
 TMAPS['end_diastole_volumep'] = TensorMap('end_diastole_volume', group='continuous', activation='linear',
                                       loss='logcosh', channel_map={'end_diastole_volume': 0},
                                       normalization={'mean': 142.0, 'std': 21.0},
-                                      parents=['output_' + MRI_SEGMENTED + '_categorical'])
+                                      parents=[TMAPS[MRI_SEGMENTED]])
 TMAPS['end_systole_volumepz'] = TensorMap('end_systole_volume', group='continuous', activation='linear',
                                       loss='logcosh', channel_map={'end_systole_volume': 0},
                                       normalization={'mean': 47.0, 'std': 10.0},
-                                      parents=['output_' + MRI_ZOOM_MASK + '_categorical'])
+                                      parents=[TMAPS[MRI_ZOOM_MASK]])
 TMAPS['end_diastole_volumepz'] = TensorMap('end_diastole_volume', group='continuous', activation='linear',
                                        loss='logcosh', channel_map={'end_diastole_volume': 0},
                                        normalization={'mean': 142.0, 'std': 21.0},
-                                       parents=['output_' + MRI_ZOOM_MASK + '_categorical'])
+                                       parents=[TMAPS[MRI_ZOOM_MASK]])
 TMAPS['ejection_fractionp'] = TensorMap('ejection_fraction', group='continuous', activation='linear',
                                     normalization={'mean': 0.50, 'std': 0.046},
                                     loss='logcosh', loss_weight=1.0, channel_map={'ejection_fraction': 0},
-                                    parents=['output_end_systole_volume_continuous',
-                                             'output_end_diastole_volume_continuous'])
+                                    parents=[TMAPS['end_systole_volume'], TMAPS['end_diastole_volume']])
 
 TMAPS['cine_segmented_sax_b1'] = TensorMap('cine_segmented_sax_b1', (256, 256, 50), group='root_array', loss='mse')
 TMAPS['cine_segmented_sax_b2'] = TensorMap('cine_segmented_sax_b2', (256, 256, 50), group='root_array', loss='mse')


### PR DESCRIPTION
We should probably add a branch consistency loss function to these like proposed [here](https://www.cv-foundation.org/openaccess/content_iccv_2015/papers/Yan_HD-CNN_Hierarchical_Deep_ICCV_2015_paper.pdf).
But hierarchical models already outperform baselines:
![architecture_graph_ecg_rest_qtc_parent_qrs](https://user-images.githubusercontent.com/2604962/72927867-fc588c80-3d24-11ea-9717-64f90035a330.png)
![architecture_graph_ecg_rest_qtc_qrs_hierarchy](https://user-images.githubusercontent.com/2604962/72927922-16926a80-3d25-11ea-8914-a5551512bced.png)
![scatters_compared_together](https://user-images.githubusercontent.com/2604962/72927946-1e520f00-3d25-11ea-8aed-06ef54793f14.png)

