### PR TITLE
augmentations field for `TensorMap`

### DIFF
--- a/ml4cvd/TensorMap.py
+++ b/ml4cvd/TensorMap.py
@@ -265,9 +265,9 @@ class TensorMap(object):
         return keras.utils.to_categorical(np.digitize(np_tensor, bins=self.discretization_bounds),
                                           num_classes=len(self.discretization_bounds) + 1)
 
-    def postprocess_tensor(self, np_tensor):
+    def postprocess_tensor(self, np_tensor, augment: bool):
         self.validator(self, np_tensor)
-        self.apply_augmentations(np_tensor)
+        np_tensor = self.apply_augmentations(np_tensor, augment)
         np_tensor = self.normalize(np_tensor)
         return self.discretize(np_tensor)
 

--- a/ml4cvd/tensor_generators.py
+++ b/ml4cvd/tensor_generators.py
@@ -257,7 +257,7 @@ class _MultiModalMultiTaskWorker:
             return self.hd5
         if self.hd5 is None:  # Don't open hd5 if everything is in the self.cache
             self.hd5 = h5py.File(path, 'r')
-        tensor = tm.postprocess_tensor(tm.tensor_from_file(tm, self.hd5, self.dependents))
+        tensor = tm.postprocess_tensor(tm.tensor_from_file(tm, self.hd5, self.dependents), augment=self.augment)
         batch[name][idx] = tensor
         if tm.cacheable:
             self.cache[path, name] = tensor


### PR DESCRIPTION
**What**
`TensorMap` gets an optional list of shape preserving augmentations that are applied in order during training, but not validation or testing.

**Why**
I've started using a lot of augmentations and have to manually implement this behavior. It will also be good for hyperoptimzation.

**How**
Modified `TensorMap` to have an `augmentations` field, and changed `tensor_generatots` to apply augmentations.

**Acceptance Criteria**
Augmentations happen during training, and not validation or testing