### PR TITLE
skip paths

### DIFF
--- a/ml4cvd/tensor_generators.py
+++ b/ml4cvd/tensor_generators.py
@@ -154,7 +154,7 @@ class TensorMapArrayCache:
     Caches numpy arrays created by tensor maps up to a maximum number of bytes
     """
 
-    def __init__(self, max_size, input_tms: List[TensorMap], output_tms: List[TensorMap], max_rows: int):
+    def __init__(self, max_size, input_tms: List[TensorMap], output_tms: List[TensorMap], max_rows: Optional[int] = np.inf):
         input_tms = [tm for tm in input_tms if tm.cacheable]
         output_tms = [tm for tm in output_tms if tm.cacheable]
         self.max_size = max_size


### PR DESCRIPTION
* Paths are skipped if any `TensorMap` fails. Expects failure to be deterministic.
* Autoencoder style tmaps should only be cached once
* Cache print output is more explanatory
* I printed the path and the value during tensor generation of autoencoded values to make sure the results were correct.
```
Worker validation_worker_0 - In true epoch 37:
        The following errors occurred:
                [skipped_paths] - 946
        Generator looped & shuffled over 3286 paths.
        2339 tensors were presented.
        946 paths were skipped because they previously failed.
        The cache has had 589449 hits. input_protocol_categorical has 3274 / 3286 tensors - input_23104_Body-mass-index-BMI_0_0_continuous has 3217 / 3286 tensors - input_Genetic-sex_Male_0_0_categorical has 3217 / 3286 tensors - input_age_continuous has 3217 / 3286 tensors - input_cigarettes_categorical has 3217 / 3286 tensors - input_diabetes_all_categorical has 3217 / 3286 tensors - input_resting_hr_continuous has 3215 /
3286 tensors.
        12.59 seconds elapsed.
```