### PR TITLE
clarify cross reference output using user given names

### DIFF
--- a/ml4cvd/arguments.py
+++ b/ml4cvd/arguments.py
@@ -202,11 +202,13 @@ def parse_args():
 
     # Cohort cross referencing arguments
     parser.add_argument('--src_tensors', help='Tensors to cross reference.')
+    parser.add_argument('--src_name', default='src', help='Name of the source cohort.')
     parser.add_argument('--src_key_join', help='Key to cross reference source tensors on.')
     parser.add_argument('--src_key_time', nargs=2, metavar=('SRC_KEY_TIME', 'SRC_KEY_TIME_FORMAT'), help='Key and format (python strftime format) to time in source tensors.')
     parser.add_argument('--src_tensor_maps', default=[], help='Do not set this directly. This is automatically set.')
 
     parser.add_argument('--dst_tensors', help='Tensors to use as a cross reference.')
+    parser.add_argument('--dst_name', default='dst', help='Name of the destination cohort.')
     parser.add_argument('--dst_key_join', help='Key to cross reference destination tensors on.')
     parser.add_argument('--dst_key_time', nargs=2, metavar=('DST_KEY_TIME', 'DST_KEY_TIME_FORMAT'), help='Key and format (python strftime format) to time in destination tensors.')
     parser.add_argument('--dst_key_outcome', help='Key to outcome in destination tensors.')
@@ -285,16 +287,13 @@ def _process_args(args):
         raise ValueError(f'learning_rate_schedule is not compatible with ReduceLROnPlateau. Set patience > epochs.')
 
     if args.src_tensors and os.path.isdir(args.src_tensors):
-        args.src_tensor_maps = [
-            _get_tmap(args.src_key_join),
-            _get_tmap(args.src_key_time[0])
-        ]
+        needed_tensor_maps = [args.src_key_join, args.src_key_time[0]]
+        args.src_tensor_maps = [_get_tmap(tm, needed_tensor_maps) for tm in needed_tensor_maps]
     if args.dst_tensors and os.path.isdir(args.dst_tensors):
-        args.dst_tensor_maps = [
-            _get_tmap(args.dst_key_join),
-            _get_tmap(args.dst_key_time[0]),
-            _get_tmap(args.dst_key_outcome)
-        ]
+        needed_tensor_maps = [args.dst_key_join, args.dst_key_time[0], args.dst_key_outcome]
+        if args.dst_key_before_outcome_time:
+            needed_tensor_maps.append(args.dst_key_before_outcome_time)
+        args.dst_tensor_maps = [_get_tmap(tm, needed_tensor_maps) for tm in needed_tensor_maps]
 
     np.random.seed(args.random_seed)
 

--- a/run_cross_reference.sh
+++ b/run_cross_reference.sh
@@ -8,9 +8,11 @@ pip install ${HOME_DIR}/repos/ml/.
 
 python ${HOME}/repos/ml/ml4cvd/recipes.py \
     --mode cross_reference \
+    --src_name ECG \
     --src_tensors /data/partners_ecg/mgh_muse_rest_ecg_metadata.csv \
     --src_key_join mrn \
     --src_key_time acquisition_date '%Y-%m-%d %H:%M:%S.%f' \
+    --dst_name 'Blake 08' \
     --dst_tensors /data/icu/blake_8_metadata.csv \
     --dst_key_join MRN \
     --dst_key_time tDischarge '%Y-%m-%d %H:%M:%S' \


### PR DESCRIPTION
User now specifies cohort names using `--src_name` and `--dst_name`.

Example output of `summary_cohort_counts.csv`:

```
                                                                               count
ECG mrn                                                                        5000000
unique ECG mrn                                                                 900000
Blake 08 MRN                                                                   5000
unique Blake 08 MRN                                                            2500
ECG mrn in Blake 08                                                            50000
unique ECG mrn in Blake 08                                                     2000
Blake 08 MRN in ECG                                                            4000
unique Blake 08 MRN in ECG                                                     2000
ECG in Blake 08 between Blake 08 tAdmit and tDischarge                         20000
unique ECG in Blake 08 between Blake 08 tAdmit and tDischarge                  1500
most recent ECG in Blake 08 between Blake 08 tAdmit and tDischarge             1500
unique and most recent ECG in Blake 08 between Blake 08 tAdmit and tDischarge  1500

```

Example file names:
`summary_all_ECG_between_Blake_08_tAdmit_and_tDischarge.csv`
`list_all_ECG_between_Blake_08_tAdmit_and_tDischarge.csv`
`distribution_all_ECG_between_Blake_08_tAdmit_and_tDischarge.png`

resolves #188 
