### PR TITLE
ignore build folder from pip 20.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ recipes_output/*
 ml4cvd.egg-info/*
 .Rproj.user
 docker/terra_image/*/**
+build/


### PR DESCRIPTION
pip 20.1 came out a few days ago and new docker images use latest pip

pip install now creates a `build` directory (see [changelog](https://pip.pypa.io/en/stable/news/#b1-2020-04-21) "Building of local directories is now done in place" and this [issue](https://github.com/pypa/pip/issues/8165))

this PR just adds that directory to .gitignore