### PR TITLE
Reuse the ml4cvd dependencies file to build the custom Terra image.

### DIFF
--- a/docker/terra_image/Dockerfile
+++ b/docker/terra_image/Dockerfile
@@ -14,7 +14,11 @@ COPY --chown=jupyter-user:users ml4cvd $HOME/ml4cvd_pkg/ml4cvd
 COPY --chown=jupyter-user:users config $HOME/ml4cvd_pkg/config
 ENV PYTHONPATH $PYTHONPATH:$HOME/ml4cvd_pkg
 
-RUN pip3 install -r $HOME/ml4cvd_pkg/config/tensorflow-requirements.txt \
+RUN pip3 install --user -r $HOME/ml4cvd_pkg/config/tensorflow-requirements.txt \
+  # Upgrade to a newer version so that %%bigquery does not print the
+  # first few rows of the downloaded dataframe of query results.
+  # Pin version due to https://github.com/googleapis/google-cloud-python/issues/9965
+  && pip3 install --upgrade --user google-cloud-bigquery[pandas]==1.22.0 \
   # Configure notebook extensions.
   && jupyter nbextension install --user --py vega \
   && jupyter nbextension enable --user --py vega

--- a/docker/terra_image/README.md
+++ b/docker/terra_image/README.md
@@ -3,6 +3,7 @@
 To build and push:
 ```
 mv ml4cvd ml4cvdBAK_$(date +"%Y%m%d_%H%M%S") \
+  && mv config configBAK_$(date +"%Y%m%d_%H%M%S") \
   && cp -r ../../ml4cvd . \
   && cp -r ../vm_boot_images/config . \
   && gcloud --project uk-biobank-sek-data builds submit \

--- a/notebooks/review_results/identify_a_sample_to_review.ipynb
+++ b/notebooks/review_results/identify_a_sample_to_review.ipynb
@@ -16,7 +16,7 @@
     "<div class=\"alert alert-block alert-warning\">\n",
     "    This notebook assumes:\n",
     "    <ul>\n",
-    "        <li><b>Terra</b> is running custom Docker image <kbd>gcr.io/uk-biobank-sek-data/ml4cvd_terra:20200601_153251</kbd>.</li>\n",
+    "        <li><b>Terra</b> is running custom Docker image <kbd>gcr.io/uk-biobank-sek-data/ml4cvd_terra:20200601_163801</kbd>.</li>\n",
     "        <li><b>ml4cvd</b> is running custom Docker image <kbd>gcr.io/broad-ml4cvd/deeplearning:tf2-latest-gpu</kbd>.</li>\n",
     "    </ul>\n",
     "</div>"

--- a/notebooks/review_results/review_one_sample.ipynb
+++ b/notebooks/review_results/review_one_sample.ipynb
@@ -16,7 +16,7 @@
     "<div class=\"alert alert-block alert-warning\">\n",
     "    This notebook assumes\n",
     "    <ul>\n",
-    "        <li><b>Terra</b> is running custom Docker image <kbd>gcr.io/uk-biobank-sek-data/ml4cvd_terra:20200601_153251</kbd>.</li>\n",
+    "        <li><b>Terra</b> is running custom Docker image <kbd>gcr.io/uk-biobank-sek-data/ml4cvd_terra:20200601_163801</kbd>.</li>\n",
     "        <li><b>ml4cvd</b> is running custom Docker image <kbd>gcr.io/broad-ml4cvd/deeplearning:tf2-latest-gpu</kbd>.</li>\n",
     "    </ul>\n",
     "</div>"


### PR DESCRIPTION
Also updated the notebooks to reflect 
* the updated path to the required Terra Docker image to use when running the notebooks on Terra
* that Facets are now working again on Terra

See https://app.terra.bio/#workspaces/uk-biobank-sek/Kathiresan%20Lab%20UK%20Biobank%20ECG for the updated docker and notebooks in use on Terra.