### PR TITLE
Tensorize amplitude measurements from Partners XMLs

### DIFF
--- a/scripts/jupyter.sh
+++ b/scripts/jupyter.sh
@@ -101,9 +101,8 @@ ${GPU_DEVICE} \
 --ipc=host \
 -v /home/${USER}/:/home/${USER}/ \
 -v /mnt/:/mnt/ \
--v /data/:/data/ \
 -p 0.0.0.0:${PORT}:${PORT} \
-${DOCKER_IMAGE} /bin/bash -c "pip install -e /home/${USER}/ml; pip install pylama; apt update; apt install git -y; jupyter notebook --no-browser --ip=0.0.0.0 --port=${PORT} --NotebookApp.token= --allow-root --notebook-dir=/home/${USER}"
+${DOCKER_IMAGE} /bin/bash -c "pip install -e /home/${USER}/ml; jupyter notebook --no-browser --ip=0.0.0.0 --port=${PORT} --NotebookApp.token= --allow-root --notebook-dir=/home/${USER}"
 
 
 # Automatically back up any local notebooks and artifacts non-recursively (no subfolders)


### PR DESCRIPTION
Closes #330 

Extracts arrays of 12 elements (one per lead) for each of the features (area, duration, peak, and start) and for each of the waves reported in the XML (e.g, P, Q, R, S, T,  STJ, RPM etc.). 

HD5 key: `measuredamplitudepeak_IE_Q` --> peak Q-wave voltage.

Arrays are encoded as floats, and `nans` flag measurements that are missing for some leads.