### PR TITLE
synchronize with signals and fix tensors presented

### DIFF
--- a/ml4cvd/tensor_generators.py
+++ b/ml4cvd/tensor_generators.py
@@ -805,13 +805,8 @@ def test_train_valid_tensor_generators(
         )
         weights = None
 
-    if num_workers:
-        num_train, num_valid, num_test = len(train_paths), len(valid_paths), len(test_paths)
-        num_train_workers = math.ceil(num_train / batch_size)
-        num_valid_workers = math.ceil(num_valid / batch_size)
-    else:
-        num_train_workers = 0
-        num_valid_workers = 0
+    num_train_workers = int(training_steps / (training_steps + validation_steps) * num_workers) or (1 if num_workers else 0)
+    num_valid_workers = int(validation_steps / (training_steps + validation_steps) * num_workers) or (1 if num_workers else 0)
     generate_train = TensorGenerator(batch_size, tensor_maps_in, tensor_maps_out, train_paths, num_train_workers, cache_size, weights, keep_paths, mixup_alpha, name='train_worker', siamese=siamese, augment=True, sample_weight=sample_weight)
     generate_valid = TensorGenerator(batch_size, tensor_maps_in, tensor_maps_out, valid_paths, num_valid_workers, cache_size, weights, keep_paths, name='validation_worker', siamese=siamese, augment=False)
     generate_test = TensorGenerator(batch_size, tensor_maps_in, tensor_maps_out, test_paths, num_workers, 0, weights, keep_paths or keep_paths_test, name='test_worker', siamese=siamese, augment=False)


### PR DESCRIPTION
resolves #323 
resolves #346

this PR aims to use more reliable and portable python functions (no longer using `qsize`), to fix the number of tensors presented `(i + 1) % ...` and to fix 2 possible concurrency edge cases:

1. consumer dequeues more items than originally produced at time of decision to consume. current code only blocks producers when `qsize == num_workers` and consumer consumes until the queue is empty (see appendix for current code). this opens the door for this scenario:
```
let's say workers = 4
1. 4 workers put things into queue and block while the queue is full
2. consumer begins to dequeue and pops 1 item off the queue
3. workers begin putting more items into the queue because queue is no longer "full"
4. consumer pops from queue until queue is empty
at this point, consumer has consumed more than the 4 items it originally wanted.
```

the fix is to have producers wait until the consumer gives the "all clear" to begin producing again. the consumer waits for all the producers to have enqueued, processes all the items, and then gives the all clear. concurrently, the producers are waiting to produce the next item.

2.  the other edge case is for a single producer to enqueue more than once before the consumer dequeues. this example in the current code can happen: 
```
let's say workers = 2
1. worker 0 enqueues an item
2. worker 1 is lazy
3. worker 0 enqueues another item
4. consumer detects 2 items in queue, start to dequeue
worker 0 has just reported stats for the same set of paths twice, as each worker gets a distinct set of paths
```

the fix is again to have the producers wait until the "all clear" is given before enqueuing the next set of items.



Appendix:

current consumer code:
https://github.com/broadinstitute/ml/blob/dd13b4518b3547ebdcad13698f0c71a4abaaafb8/ml4cvd/tensor_generators.py#L171-L186

current producer code:
https://github.com/broadinstitute/ml/blob/dd13b4518b3547ebdcad13698f0c71a4abaaafb8/ml4cvd/tensor_generators.py#L426-L437