### PR TITLE
Add .lfsconfig to repo?

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@ notebooks/**.ipynb filter=nbstripout
 *.osx filter=lfs diff=lfs merge=lfs -text
 *.genes filter=lfs diff=lfs merge=lfs -text
 model_zoo/ECG_PheWAS/*.h5 filter=lfs diff=lfs merge=lfs -text
+model_zoo/DROID/encoders/**/* filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,2 @@
+[lfs]
+	url = git@github.com:broadinstitute/ml4h.git


### PR DESCRIPTION
I had to add the url to a .lfsconfig file to be able to push lfs tracked files. Thought it might be helpful to add this to the repo itself