### PR TITLE
fixed issue where validate would fail on large directories.

### DIFF
--- a/scripts/validate_tensors.sh
+++ b/scripts/validate_tensors.sh
@@ -10,6 +10,6 @@ INPUT_TENSORS_DIR=$1
 NUMBER_OF_THREADS=$2
 
 
-find ${INPUT_TENSORS_DIR}/*.hd5 | \
+find ${INPUT_TENSORS_DIR} | grep ".hd5" | \
     xargs -P ${NUMBER_OF_THREADS} -I {} \
         bash -c "h5dump -n {} | (grep -q 'HDF5 \"{}\"' && echo 'OK - {}' || echo 'BAD - {}')"


### PR DESCRIPTION
this was doing a find with a wildcard, which led to the "Arguments list too long" error - grep instead for filter