### PR TITLE
removing full requirements from setup.py and limiting to tests/docker

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,7 @@ jobs:
         python -m pip install --upgrade pip
         # Install the ml4h Python package.
         pip install .
+        pip install -r ../../docker/vm_boot_images/config/tensorflow-requirements.txt
     - name: Test with pytest
       run: |
         pytest tests -m "not slow"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 
 here = pathlib.Path(__file__).parent.resolve()
 # Get the requirements from the requirements file
-requirements = (here / 'docker/vm_boot_images/config/tensorflow-requirements.txt').read_text(encoding='utf-8')
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 setup(
     name='ml4h',
@@ -13,7 +12,6 @@ setup(
     long_description_content_type='text/markdown',
     url='https://github.com/broadinstitute/ml4h',
     python_requires='>=3.6',
-    #install_requires=["ml4ht", "tensorflow", "pytest", "numcodecs"], # requirements
-    install_requires=requirements,
+    install_requires=["ml4ht", "tensorflow", "pytest", "numcodecs"], # requirements
     packages=find_packages(),
 )


### PR DESCRIPTION
Right now for releasing, you need to comment out setup.py full requirements for the push to pypi, and then revert back to full requirements for docker build/tests.  Instead switched to `pip install local/from pypi` for minimal, and` pip install -r requirements.txt` when the full is needed - docker was already installing requirements.txt - added that also to the test gh actions yml