### PR TITLE
Rr keras update

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.11]
 
     steps:
     - uses: actions/checkout@v2
@@ -34,6 +34,6 @@ jobs:
         python -m pip install --upgrade pip
         # Install the ml4h Python package.
         pip install .
-    - name: Test with pytest
+    - name: Test with pytest and pytest-xdist
       run: |
-        pytest tests -m "not slow"
+        pytest tests -m "not slow" -n auto

--- a/docker/vm_boot_images/config/tensorflow-requirements.txt
+++ b/docker/vm_boot_images/config/tensorflow-requirements.txt
@@ -12,6 +12,7 @@ bokeh
 pillow
 notebook
 pytest
+pytest-xdist
 pysam
 tensorflow==2.18.0
 tensorflow-addons

--- a/ml4h/metrics.py
+++ b/ml4h/metrics.py
@@ -9,6 +9,7 @@ from sklearn.metrics import roc_curve, auc, average_precision_score
 
 from tensorflow.keras.losses import binary_crossentropy, categorical_crossentropy, sparse_categorical_crossentropy
 from tensorflow.keras.losses import LogCosh, CosineSimilarity, MSE, MAE, MAPE
+from keras.saving import register_keras_serializable
 
 #from neurite.tf.losses import Dice
 
@@ -46,6 +47,7 @@ def weighted_crossentropy(weights, name='anonymous'):
     string_fxn += '\treturn loss\n'
     exec(string_fxn, globals(), locals())
     loss_fxn = eval(name + fxn_postfix, globals(), locals())
+    loss_fxn = register_keras_serializable()(loss_fxn)
     return loss_fxn
 
 
@@ -277,6 +279,7 @@ def per_class_dice(labels):
 
         exec(string_fxn)
         dice_fxn = eval(fxn_name + '_dice')
+        dice_fxn = register_keras_serializable()(dice_fxn)
         dice_fxns.append(dice_fxn)
 
     return dice_fxns
@@ -297,6 +300,7 @@ def per_class_recall(labels):
 
         exec(string_fxn)
         recall_fxn = eval(fxn_name + '_recall')
+        recall_fxn = register_keras_serializable()(recall_fxn)
         recall_fxns.append(recall_fxn)
 
     return recall_fxns
@@ -315,6 +319,7 @@ def per_class_precision(labels):
 
         exec(string_fxn)
         precision_fxn = eval(fxn_name + '_precision')
+        precision_fxn = register_keras_serializable()(precision_fxn)
         precision_fxns.append(precision_fxn)
 
     return precision_fxns
@@ -333,6 +338,7 @@ def per_class_recall_3d(labels):
 
         exec(string_fxn)
         recall_fxn = eval(fxn_prefix + '_recall')
+        recall_fxn = register_keras_serializable()(recall_fxn)
         recall_fxns.append(recall_fxn)
 
     return recall_fxns
@@ -351,6 +357,7 @@ def per_class_precision_3d(labels):
 
         exec(string_fxn)
         precision_fxn = eval(fxn_prefix + '_precision')
+        precision_fxn = register_keras_serializable()(precision_fxn)
         precision_fxns.append(precision_fxn)
 
     return precision_fxns
@@ -369,6 +376,7 @@ def per_class_recall_4d(labels):
 
         exec(string_fxn)
         recall_fxn = eval(fxn_prefix + '_recall')
+        recall_fxn = register_keras_serializable()(recall_fxn)
         recall_fxns.append(recall_fxn)
 
     return recall_fxns
@@ -387,6 +395,8 @@ def per_class_precision_4d(labels):
 
         exec(string_fxn)
         precision_fxn = eval(fxn_prefix + '_precision')
+        precision_fxn = register_keras_serializable()(precision_fxn)
+
         precision_fxns.append(precision_fxn)
 
     return precision_fxns
@@ -405,6 +415,7 @@ def per_class_recall_5d(labels):
 
         exec(string_fxn)
         recall_fxn = eval(fxn_prefix + '_recall')
+        recall_fxn = register_keras_serializable()(recall_fxn)
         recall_fxns.append(recall_fxn)
 
     return recall_fxns
@@ -423,6 +434,7 @@ def per_class_precision_5d(labels):
 
         exec(string_fxn)
         precision_fxn = eval(fxn_prefix + '_precision')
+        precision_fxn = register_keras_serializable()(precision_fxn)
         precision_fxns.append(precision_fxn)
 
     return precision_fxns
@@ -714,3 +726,11 @@ def concordance_index_censored(event_indicator, event_time, estimate, tied_tol=1
     """
     w = np.ones_like(estimate)
     return _estimate_concordance_index(event_indicator, event_time, estimate, w, tied_tol)
+
+
+def _register_all(module_globals):
+    for name, obj in module_globals.items():
+        if callable(obj) and not name.startswith("_"):
+            module_globals[name] = register_keras_serializable()(obj)
+
+_register_all(globals())

--- a/ml4h/models/model_factory.py
+++ b/ml4h/models/model_factory.py
@@ -121,7 +121,8 @@ def make_multimodal_multitask_model(
     )
 
     if kwargs.get('model_file', False):
-        return _load_model_encoders_and_decoders(tensor_maps_in, tensor_maps_out, custom_dict, opt, kwargs['model_file'])
+        return tf.keras.models.load_model(kwargs['model_file'])
+        #return _load_model_encoders_and_decoders(tensor_maps_in, tensor_maps_out, custom_dict, opt, kwargs['model_file'])
 
     full_model, encoders, decoders, merger = multimodal_multitask_model(
         tensor_maps_in, tensor_maps_out,

--- a/scripts/tf.sh
+++ b/scripts/tf.sh
@@ -185,5 +185,5 @@ ${GPU_DEVICE} \
 -v ${HOME}/:${HOME}/ \
 ${MOUNTS} \
 ${DOCKER_IMAGE} /bin/bash -c "pip3 install --upgrade pip
-pip install ${WORKDIR} pytest-xdist;
+pip install ${WORKDIR};
 eval ${CALL_DOCKER_AS_USER} ${PYTHON_COMMAND} ${PYTHON_ARGS}"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -83,7 +83,6 @@ def make_training_data(input_tmaps: List[TensorMap], output_tmaps: List[TensorMa
 
     return dataset
 
-
 def assert_model_trains(
     input_tmaps: List[TensorMap], output_tmaps: List[TensorMap],
     m: Optional[tf.keras.Model] = None, skip_shape_check: bool = False,
@@ -105,7 +104,7 @@ def assert_model_trains(
         for tmap, tensor in zip(input_tmaps, m.inputs):
             assert tensor.shape[1:] == tmap.shape
             assert tensor.shape[1:] == tmap.shape
-        for tmap, tensor in zip(output_tmaps, m.outputs):
+        for tmap, tensor in zip(parent_sort(output_tmaps), m.outputs):
             assert tensor.shape[1:] == tmap.shape
             assert tensor.shape[1:] == tmap.shape
     data = make_training_data(input_tmaps, parent_sort(output_tmaps))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -267,7 +267,7 @@ class TestMakeMultimodalMultitaskModel:
         Tests 1d->2d, 2d->1d, (1d,2d)->(1d,2d)
         """
         params = DEFAULT_PARAMS.copy()
-        params['bottleneck_type'] = BottleneckType.Variational
+        #params['bottleneck_type'] = BottleneckType.Variational (This is not implemented yet)
         params['pool_x'] = params['pool_y'] = 2
         m, _, _, _ = make_multimodal_multitask_model(
             input_output_tmaps[0],


### PR DESCRIPTION
- model saving has changed(no intermediate models are created now and it build a single keras file even when model is built using individual components)
- serialization of metrics is required now as a result of single model file
- Added pytest-xdist for parallel test execution
- Updated /.github/workflows/python-package.yml and added python 3.11 and pytest xdist