### PR TITLE
Fix macOS multiprocessing deadlock and add ARM64 Docker support

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,39 @@
+name: Build ARM64 Docker image
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build-arm64:
+    name: Build & push ARM64 image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU for cross-platform emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/vm_boot_images/
+          file: docker/vm_boot_images/Dockerfile.arm64
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/broadinstitute/ml4h:arm64-latest-cpu

--- a/docker/vm_boot_images/Dockerfile.arm64
+++ b/docker/vm_boot_images/Dockerfile.arm64
@@ -1,0 +1,30 @@
+# ARM64 (Apple Silicon / linux/arm64) image for ml4h.
+# Build with:
+#   docker buildx build --platform linux/arm64 -f Dockerfile.arm64 -t ml4h:arm64-cpu .
+#
+# tensorflow/tensorflow has no arm64 GPU variant; CPU-only is the supported path.
+
+ARG BASE_IMAGE=tensorflow/tensorflow:2.19.0
+FROM --platform=linux/arm64 ${BASE_IMAGE}
+
+LABEL maintainer="ml4h contributors"
+
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+COPY ./config/* /app/
+WORKDIR /app
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-tk \
+        libgl1-mesa-glx libxt-dev \
+        wget unzip curl git ffmpeg \
+        python3-pydot graphviz && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --upgrade pip
+
+# constraints.txt pins versions known to work; override individual packages
+# below only when an arm64 wheel is unavailable in the constraint set.
+RUN pip3 install -r tensorflow-requirements.txt -c constraints.txt

--- a/docker/vm_boot_images/build.sh
+++ b/docker/vm_boot_images/build.sh
@@ -16,6 +16,7 @@ GITHUB_REPO="ghcr.io/broadinstitute/ml4h"
 TAG=$( git rev-parse --short HEAD )
 CONTEXT="docker/vm_boot_images/"
 CPU_ONLY="false"
+ARM64="false"
 PUSH_TO_GCR="false"
 PUSH_TO_LATEST="false"
 
@@ -43,13 +44,16 @@ usage()
     It assumes 'gcloud' has been installed, Docker has been configured to use 'gcloud' as a credential helper
     by running 'gcloud auth configure-docker', and the script is being run at the root of the GitHub repo clone.
 
-    Usage: ${SCRIPT_NAME} [-d <path>] [-t <tag>] [-chp]
+    Usage: ${SCRIPT_NAME} [-d <path>] [-t <tag>] [-achpP]
 
     Example: ./${SCRIPT_NAME} -d /Users/kyuksel/github/ml4h/jamesp/docker/deeplearning -cp
 
         -d      <path>      Path to directory where Dockerfile is located. Default: '${CONTEXT}'
 
         -t      <tag>       String used to tag the Docker image. Default: short version of the latest commit hash
+
+        -a                  Build a linux/arm64 image using Dockerfile.arm64 (Apple Silicon / ARM servers).
+                            Requires 'docker buildx' with an arm64-capable builder.
 
         -c                  Build off of the cpu-only base image and tag image also as '${LATEST_TAG_CPU}'.
                             Default: Build image to run on GPU-enabled machines and tag image also as '${LATEST_TAG_GPU}'.
@@ -64,7 +68,7 @@ USAGE_MESSAGE
 
 ################### OPTION PARSING #######################################
 
-while getopts ":d:t:chpP" opt ; do
+while getopts ":d:t:achpP" opt ; do
     case ${opt} in
         h)
             usage
@@ -75,6 +79,9 @@ while getopts ":d:t:chpP" opt ; do
             ;;
         t)
             TAG=$OPTARG
+            ;;
+        a)
+            ARM64="true"
             ;;
         c)
             CPU_ONLY="true"
@@ -101,6 +108,22 @@ shift $((OPTIND - 1))
 
 ################### SCRIPT BODY ##########################################
 
+if [[ ${ARM64} == "true" ]]; then
+    LATEST_TAG="arm64-latest-cpu"
+    TAG="${TAG}-arm64-cpu"
+    echo -e "${BLUE}Building ARM64 image '${REPO}:${TAG}'...${NC}"
+    docker buildx build ${CONTEXT} \
+        --platform linux/arm64 \
+        --file "${CONTEXT}/Dockerfile.arm64" \
+        --tag "${REPO}:${TAG}" \
+        --tag "${REPO}:${LATEST_TAG}" \
+        --tag "${GITHUB_REPO}:${TAG}" \
+        --tag "${GITHUB_REPO}:${LATEST_TAG}" \
+        --network host \
+        --load
+    exit 0
+fi
+
 echo CPU_ONLY $CPU_ONLY
 if [[ ${CPU_ONLY} == "true" ]]; then
     BASE_IMAGE=${BASE_IMAGE_CPU}
@@ -114,7 +137,6 @@ fi
 
 echo BASE_IMAGE $BASE_IMAGE LATEST_TAG $LATEST_TAG
 echo -e "${BLUE}Building Docker image '${REPO}:${TAG}' from base image '${BASE_IMAGE}', and also tagging it as '${LATEST_TAG}'...${NC}"
-# --network host allows for the container's network stack to use the Docker host's network
 docker build ${CONTEXT} \
     --build-arg BASE_IMAGE=${BASE_IMAGE} \
     --tag "${REPO}:${TAG}" \

--- a/ml4h/tensor_generators.py
+++ b/ml4h/tensor_generators.py
@@ -21,6 +21,13 @@ import numpy as np
 import pandas as pd
 from collections import Counter
 from multiprocessing import Process, Queue
+import multiprocessing
+import platform
+
+# On macOS, 'fork' after TF initialization is unreliable; use 'spawn' instead.
+if platform.system() == 'Darwin' and multiprocessing.get_start_method(allow_none=True) is None:
+    multiprocessing.set_start_method('spawn')
+
 from itertools import chain
 from typing import List, Dict, Tuple, Set, Optional, Iterator, Callable, Any, Union, Type
 


### PR DESCRIPTION
Addresses #375 and #574. On macOS, Python defaults to fork after TensorFlow initializes, causing deadlocks in multiprocessing workers. Additionally, there is no native ARM64/Apple Silicon support in the Docker build infrastructure.

tensor_generators.py: Added a Darwin platform guard that sets multiprocessing start method to spawn, using allow_none=True to prevent RuntimeError on re-import.
Dockerfile.arm64: New ARM64-native image based on tensorflow/tensorflow:2.19.0 targeting linux/arm64.
build.sh: Added -a flag routing through docker buildx for cross-platform builds.
.github/workflows/build-arm64.yml: CI pipeline for automated ARM64 builds via QEMU.