### PR TITLE
Added Modified Chefer rollout method for attention maps and visualization

### DIFF
--- a/ml4h/models/transformer_blocks_embedding.py
+++ b/ml4h/models/transformer_blocks_embedding.py
@@ -513,16 +513,21 @@ def build_general_embedding_transformer(
 
     attn_mask = AttentionMaskLayer(name="attn_mask")(inp_mask)  # (B,1,T)
 
+    #Collect Attention scores for explainability
+    all_attn_scores = []
     # ------------------------------
     # TRANSFORMER LAYERS
     # ------------------------------
     for i in range(num_layers):
-        attn = layers.MultiHeadAttention(
+        attn_layer = layers.MultiHeadAttention(
             num_heads=num_heads,
             key_dim=transformer_dim // num_heads,
             dropout=dropout,
             name=f"mha_{i}",
-        )(x, x, attention_mask=attn_mask)
+        )
+        attn, scores = attn_layer(x, x, attention_mask=attn_mask, return_attention_scores=True)
+
+        all_attn_scores.append(scores)  # (B, heads, T, T)
 
         attn = layers.Dropout(dropout, name=f"attn_dropout_{i}")(attn)
         x = layers.Add(name=f"attn_residual_{i}")([x, attn])
@@ -577,6 +582,14 @@ def build_general_embedding_transformer(
 
     model = keras.Model(inputs, outputs)
 
+    # explain_model: same weights, adds attention maps + pooling weights as outputs
+    explain_outputs = {**outputs}
+    explain_outputs["attn_wts"] = wts
+
+    for i, s in enumerate(all_attn_scores):
+        explain_outputs[f"mha_{i}_scores"] = s
+    model_explain = keras.Model(inputs, explain_outputs, name="explain_model")
+
     losses = {t: "mse" for t in regression_targets}
     losses.update({t: "binary_crossentropy" for t in binary_targets})
     if label_weights:
@@ -606,7 +619,7 @@ def build_general_embedding_transformer(
         metrics=metrics_dict,
     )
 
-    return model
+    return model, model_explain
 
 
 @keras.saving.register_keras_serializable(package="ml4h")
@@ -710,10 +723,14 @@ def build_embedding_transformer(
     m_k = ExpandDimsLayer(axis=1, name='mask_k')(inp_mask)
     mask_2d = LogicalAndLayer(name='mask_qk')([m_q, m_k])
 
+    all_attn_scores = []
     # Transformer blocks
     for i in range(num_layers):
-        attn = layers.MultiHeadAttention(num_heads=num_heads, key_dim=transformer_dim // num_heads,
-                                         dropout=dropout, name=f'mha_{i}')(x, x, attention_mask=mask_2d)
+        attn_layer = layers.MultiHeadAttention(num_heads=num_heads, key_dim=transformer_dim // num_heads,
+                                         dropout=dropout, name=f'mha_{i}')
+        attn, scores = attn_layer(x, x, attention_mask=mask_2d, return_attention_scores=True)
+        all_attn_scores.append(scores)
+
         attn = layers.Dropout(dropout)(attn)
         x = layers.LayerNormalization(epsilon=1e-6, name=f'ln1_{i}')(layers.Add()([x, attn]))
 
@@ -750,9 +767,20 @@ def build_embedding_transformer(
         outputs[t] = layers.Dense(num_classes, activation='softmax', name=t)(h)
 
     if view2id is not None:
-        model = keras.Model(inputs={'view': inp_view, 'num': inp_num, 'mask': inp_mask}, outputs=outputs)
+        model_inputs = {'view': inp_view, 'num': inp_num, 'mask': inp_mask}
     else:
-        model = keras.Model(inputs={'num': inp_num, 'mask': inp_mask}, outputs=outputs)
+        model_inputs = {'num': inp_num, 'mask': inp_mask}
+
+    model = keras.Model(inputs=model_inputs, outputs=outputs)
+
+    # explain_model: same weights, adds attention maps + pooling weights as outputs
+    explain_outputs = {**outputs}
+    explain_outputs["attn_wts"] = wts
+
+    for i, s in enumerate(all_attn_scores):
+        explain_outputs[f"mha_{i}_scores"] = s
+    model_explain = keras.Model(model_inputs, explain_outputs, name="explain_model")
+
     # Losses / metrics
     losses = {t: 'mse' for t in regression_targets}
     for t in binary_targets:
@@ -786,7 +814,7 @@ def build_embedding_transformer(
         metrics=metrics
     )
 
-    return model
+    return model, model_explain
 
 
 def evaluate_multitask_on_dataset(

--- a/ml4h/models/transformer_interpretability.py
+++ b/ml4h/models/transformer_interpretability.py
@@ -1,0 +1,475 @@
+"""
+Chefer et al., CVPR 2021 — "Transformer Interpretability Beyond Attention Visualization"
+Gradient-weighted attention rollout for encoder-only transformers.
+
+Usage (inference only — model weights are never modified):
+
+    relevancy = compute_relevancy_scores(
+        model=trained_model,
+        inputs=batch_inputs_dict,
+        target_name="my_binary_target",
+        num_layers=4,
+    )
+    # relevancy: np.ndarray of shape (B, T), rows sum to ~1.0
+    # Each value is the relevancy of that visit/token to the prediction.
+"""
+
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+import keras
+from keras import layers as klayers
+import matplotlib.pyplot as plt
+
+def detect_transformer_builder_type(model):
+    input_names = [x.name.split(":")[0] for x in model.inputs]
+
+    if "latent" in input_names:
+        return "general_embedding_transformer"
+
+    if "num" in input_names and "mask" in input_names:
+        return "embedding_transformer"
+
+    raise ValueError(f"Unknown transformer type. Inputs found: {input_names}")
+
+
+def extract_build_args_from_transformer_model(model):
+    builder_type = detect_transformer_builder_type(model)
+
+    output_names = model.output_names
+
+    regression_targets = []
+    binary_targets = []
+    categorical_targets = []
+    num_classes = None
+
+    for name in output_names:
+        layer = model.get_layer(name)
+        units = int(layer.units)
+        activation = layer.activation.__name__
+
+        if units == 1 and activation == "linear":
+            regression_targets.append(name)
+        elif units == 1 and activation == "sigmoid":
+            binary_targets.append(name)
+        elif units > 1 and activation == "softmax":
+            categorical_targets.append(name)
+            num_classes = units
+        else:
+            raise ValueError(
+                f"Cannot classify output {name}: units={units}, activation={activation}"
+            )
+
+    mha_layers = sorted(
+        [l for l in model.layers if l.name.startswith("mha_")],
+        key=lambda l: int(l.name.split("_")[1])
+    )
+
+    if not mha_layers:
+        raise ValueError("No mha_0, mha_1, ... layers found.")
+
+    num_layers = len(mha_layers)
+    num_heads = int(mha_layers[0].num_heads)
+    dropout = float(mha_layers[0].dropout)
+
+    if builder_type == "embedding_transformer":
+        inp = {x.name.split(":")[0]: x for x in model.inputs}
+
+        max_len = int(inp["num"].shape[1])
+        feat = int(inp["num"].shape[2])
+
+        token_hidden = int(model.get_layer("token_proj").units)
+
+        # In your builder, MHA key_dim uses transformer_dim // num_heads.
+        # So recover transformer_dim from key_dim * num_heads.
+        transformer_dim = int(mha_layers[0].key_dim * num_heads)
+
+        has_view = "view" in inp
+
+        view2id = None
+        emb_dim = None
+
+        if has_view:
+            view_emb = model.get_layer("view_embedding")
+            emb_dim = int(view_emb.output_dim)
+
+            # We cannot recover original category strings, only IDs.
+            # This dummy mapping preserves max id / vocab size.
+            max_id = int(view_emb.input_dim - 1)
+            view2id = {str(i): i for i in range(1, max_id + 1)}
+        else:
+            emb_dim = None
+
+        use_positional_embedding = any(l.name == "pos_embedding" for l in model.layers)
+
+        return {
+            "builder_type": builder_type,
+            "build_args": {
+                "input_numeric_cols": [f"feature_{i}" for i in range(feat)],
+                "regression_targets": regression_targets,
+                "binary_targets": binary_targets,
+                "max_len": max_len,
+                "emb_dim": emb_dim,
+                "token_hidden": token_hidden,
+                "transformer_dim": transformer_dim,
+                "num_heads": num_heads,
+                "num_layers": num_layers,
+                "dropout": dropout,
+                "view2id": view2id,
+                "learning_rate": 0.00005,
+                "binary_class_prevalences": None,
+                "categorical_targets": categorical_targets,
+                "num_classes": num_classes,
+                "label_weights": None,
+                "use_positional_embedding": use_positional_embedding,
+            },
+        }
+
+    if builder_type == "general_embedding_transformer":
+        inp = {x.name.split(":")[0]: x for x in model.inputs}
+
+        max_len = int(inp["latent"].shape[1])
+        latent_dim = int(inp["latent"].shape[2])
+
+        numeric_columns = [
+            name.replace("num_", "", 1)
+            for name in inp
+            if name.startswith("num_")
+        ]
+
+        categorical_columns = [
+            name.replace("cat_", "", 1)
+            for name in inp
+            if name.startswith("cat_")
+        ]
+
+        latent_embed = int(model.get_layer("latent_emb").units)
+        transformer_dim = int(model.get_layer("emb_projection").units)
+
+        if numeric_columns:
+            scalar_embed = int(model.get_layer(f"num_{numeric_columns[0]}_emb").units)
+        elif categorical_columns:
+            scalar_embed = int(model.get_layer(f"cat_{categorical_columns[0]}_emb").output_dim)
+        else:
+            raise ValueError("Cannot infer scalar_embed.")
+
+        categorical_vocabs = {}
+        for col in categorical_columns:
+            emb = model.get_layer(f"cat_{col}_emb")
+            categorical_vocabs[col] = int(emb.input_dim - 1)
+
+        return {
+            "builder_type": builder_type,
+            "build_args": {
+                "latent_dim": latent_dim,
+                "numeric_columns": numeric_columns,
+                "categorical_columns": categorical_columns,
+                "categorical_vocabs": categorical_vocabs,
+                "regression_targets": regression_targets,
+                "binary_targets": binary_targets,
+                "max_len": max_len,
+                "scalar_embed": scalar_embed,
+                "latent_embed": latent_embed,
+                "transformer_dim": transformer_dim,
+                "num_heads": num_heads,
+                "num_layers": num_layers,
+                "dropout": dropout,
+                "categorical_targets": categorical_targets,
+                "num_classes": num_classes,
+                "label_weights": None,
+            },
+        }
+
+def normalize_rows(A, eps=1e-8):
+    row_sum = A.sum(axis=-1, keepdims=True)
+    return A / (row_sum + eps)
+
+
+def _ordered_attn_score_keys(outputs, n_layers=None):
+    """
+    Return attention-score output keys in layer order.
+
+    Supports both naming conventions:
+        notebook style: attn_scores_0, attn_scores_1, ...
+        ml4h builder:   mha_0_scores, mha_1_scores, ...
+    """
+    keys = sorted(
+        [k for k in outputs if k.startswith("attn_scores_")],
+        key=lambda x: int(x.split("_")[-1]),
+    )
+    if not keys:
+        keys = sorted(
+            [k for k in outputs if k.startswith("mha_") and k.endswith("_scores")],
+            key=lambda x: int(x.split("_")[1]),
+        )
+    if not keys:
+        raise ValueError(
+            "No attention-score outputs found "
+            "(expected attn_scores_* or mha_*_scores)."
+        )
+    if n_layers is not None:
+        keys = keys[:n_layers]
+    return keys
+
+
+def grad_weighted_attention_rollout(
+    explainable_model,
+    batch_inputs,
+    actual_len,
+    n_layers=None,
+    target_key="prediction",
+    residual_weight=0.5,
+    attention_weight=0.5,
+    use_abs_grad=True,
+    positive_only=False,
+):
+    """
+    Modified Chefer et al. (2021) gradient-weighted attention rollout for encoder-only transformers.
+    Single-sample gradient-weighted attention rollout (Chefer et al., CVPR 2021).
+
+    This is a direct port of the reference notebook implementation
+    (grad_weighted_attention_rollout in visTrans.ipynb). It runs per layer in
+    NumPy, mixes a residual/identity path with the gradient-weighted attention
+    path, rolls the per-layer matrices together, and collapses the rollout to a
+    per-token relevance vector using a *uniform* mean over query tokens.
+
+    Inputs
+    ------
+    explainable_model:
+        Keras model whose outputs include `target_key` and per-layer attention
+        scores named either `attn_scores_{i}` or `mha_{i}_scores`.
+    batch_inputs:
+        dict of model inputs for a single sample, e.g.
+        {"num": [1, T, F], "mask": [1, T] bool} (plus "view": [1, T] if the
+        model was built with a categorical/view input). Passed to the model
+        as-is, so every required input must be present.
+    actual_len:
+        number of real (non-padded) tokens for this sample
+    n_layers:
+        number of transformer layers to use; if None, all attention-score
+        outputs are used in order.
+    target_key:
+        model output to explain (scalar head, e.g. "prediction").
+
+    use_abs_grad:
+        True:  cam = A * |dy/dA|
+        False + positive_only=True:  cam = ReLU(A * dy/dA)
+        False + positive_only=False: cam = A * dy/dA (raw signed)
+
+    Returns
+    -------
+    relevance_real:   [actual_len] normalized token relevance
+    rollout_real:     [actual_len, actual_len] rollout matrix
+    outputs_np:       dict of model outputs (numpy)
+    layer_debug_df:   per-layer diagnostics
+    layer_mats:       list of per-layer mixed matrices
+    """
+
+    mask_input = np.asarray(batch_inputs["mask"])
+    valid = mask_input[0].astype(bool)
+    valid_idx = np.where(valid)[0]
+
+    with tf.GradientTape(persistent=True) as tape:
+        outputs = explainable_model(batch_inputs, training=False)
+
+        target = outputs[target_key][0, 0]
+
+        attn_keys = _ordered_attn_score_keys(outputs, n_layers)
+        attn_scores_list = [outputs[k] for k in attn_keys]
+
+    layer_mats = []
+    layer_debug = []
+
+    for i, attn_scores in enumerate(attn_scores_list):
+        grads = tape.gradient(target, attn_scores)
+
+        if grads is None:
+            raise ValueError(f"Gradient is None for {attn_keys[i]}")
+
+        A = attn_scores[0]  # [heads, T, T]
+        G = grads[0]        # [heads, T, T]
+
+        if use_abs_grad:
+            cam = A * tf.abs(G)
+        else:
+            cam = A * G
+            if positive_only:
+                cam = tf.nn.relu(cam)
+
+        # Average across heads
+        cam = tf.reduce_mean(cam, axis=0).numpy()  # [T, T]
+
+        # Remove padded positions
+        cam[~valid, :] = 0.0
+        cam[:, ~valid] = 0.0
+
+        # Normalize gradient-weighted attention
+        cam = normalize_rows(cam)
+
+        # Residual matrix only on real tokens
+        I = np.zeros_like(cam)
+        I[valid_idx, valid_idx] = 1.0
+
+        # Mix residual path and gradient-weighted attention path
+        M = residual_weight * I + attention_weight * cam
+
+        # Remove padding again
+        M[~valid, :] = 0.0
+        M[:, ~valid] = 0.0
+
+        # Normalize rows
+        M = normalize_rows(M)
+
+        M_real = M[:actual_len, :actual_len]
+        offdiag = M_real.copy()
+        np.fill_diagonal(offdiag, 0.0)
+
+        layer_debug.append({
+            "layer": i,
+            "attn_scores_min": float(A.numpy()[:, :actual_len, :actual_len].min()),
+            "attn_scores_max": float(A.numpy()[:, :actual_len, :actual_len].max()),
+            "grad_min": float(G.numpy()[:, :actual_len, :actual_len].min()),
+            "grad_max": float(G.numpy()[:, :actual_len, :actual_len].max()),
+            "cam_sum_real": float(cam[:actual_len, :actual_len].sum()),
+            "M_diag_mean": float(np.diag(M_real).mean()),
+            "M_diag_min": float(np.diag(M_real).min()),
+            "M_diag_max": float(np.diag(M_real).max()),
+            "M_offdiag_sum": float(offdiag.sum()),
+            "M_offdiag_max": float(offdiag.max()),
+        })
+
+        layer_mats.append(M)
+
+    del tape
+
+    # Start rollout from identity over valid tokens
+    rollout = np.zeros_like(layer_mats[0])
+    rollout[valid_idx, valid_idx] = 1.0
+
+    for M in layer_mats:
+        rollout = M @ rollout
+
+    rollout_real = rollout[:actual_len, :actual_len]
+
+    # Since the model later pools all tokens, summarize source-token relevance
+    relevance_real = rollout_real.mean(axis=0)
+    relevance_real = relevance_real / (relevance_real.sum() + 1e-12)
+
+    outputs_np = {k: v.numpy() for k, v in outputs.items()}
+    layer_debug_df = pd.DataFrame(layer_debug)
+
+    return relevance_real, rollout_real, outputs_np, layer_debug_df, layer_mats
+
+
+def plot_average_rollout_importance_from_results_binned(
+    results,
+    target,
+    output_folder,
+    run_id,
+    n_position_bins=10,
+):
+    import os
+    import numpy as np
+    import pandas as pd
+    import matplotlib.pyplot as plt
+
+    rel_col = f"{target}_relevance"
+    rows = []
+
+    for sample_id, rel, n_rows in zip(
+        results["mrn"],
+        results[rel_col],
+        results["n_rows"],
+    ):
+        rel = np.asarray(rel, dtype=float)[: int(n_rows)]
+        n = len(rel)
+
+        if n == 0:
+            continue
+        if n < 2:
+                continue
+
+        uniform = 1.0 / n
+
+        for pos, score in enumerate(rel):
+            relative_position = pos / (n-1)
+
+            rows.append({
+                "sample_id": sample_id,
+                "position_index": pos,
+                "n_rows": n,
+                "relative_position": relative_position,
+                "rollout": float(score),
+                "rollout_ratio_uniform": float(score / uniform),
+            })
+
+    global_rollout_df = pd.DataFrame(rows)
+
+    overall_position_summary = (
+        global_rollout_df
+        .assign(
+            position_bin=lambda x: pd.cut(
+                x["relative_position"],
+                bins=np.linspace(0, 1, n_position_bins + 1),
+                include_lowest=True,
+            )
+        )
+        .groupby("position_bin", observed=False)
+        .agg(
+            mean_rollout_ratio=("rollout_ratio_uniform", "mean"),
+            median_rollout_ratio=("rollout_ratio_uniform", "median"),
+            sem_rollout_ratio=(
+                "rollout_ratio_uniform",
+                lambda x: x.std() / np.sqrt(len(x)),
+            ),
+            n_ecgs=("rollout_ratio_uniform", "count"),
+            n_patients=("sample_id", "nunique"),
+        )
+        .reset_index()
+    )
+
+    overall_position_summary["position_mid"] = (
+        overall_position_summary["position_bin"]
+        .apply(lambda x: x.mid)
+        .astype(float)
+    )
+
+    os.makedirs(output_folder, exist_ok=True)
+
+    summary_path = os.path.join(
+        output_folder,
+        f"overall_position_rollout_summary_{target}_{run_id}.csv",
+    )
+    overall_position_summary.to_csv(summary_path, index=False)
+
+    fig = plt.figure(figsize=(9, 5))
+
+    x = overall_position_summary["position_mid"].astype(float).values
+    y = overall_position_summary["mean_rollout_ratio"].astype(float).values
+    sem = overall_position_summary["sem_rollout_ratio"].astype(float).values
+
+    plt.plot(x, y, marker="o", label="Mean rollout / uniform")
+    plt.fill_between(x, y - sem, y + sem, alpha=0.2)
+
+    plt.axhline(
+        1.0,
+        linestyle="--",
+        linewidth=1,
+        label="Uniform baseline",
+    )
+
+    plt.xlabel(f"Relative {target}(Token) position within patient sequence")
+    plt.ylabel("Rollout relevance / uniform")
+    plt.title(f"Average rollout importance across all {target} Token-count groups")
+    plt.legend()
+    plt.tight_layout()
+
+    plot_path = os.path.join(
+        output_folder,
+        f"overall_mean_rollout_ratio_by_position_{target}_{run_id}.png",
+    )
+
+    fig.savefig(plot_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+
+    return global_rollout_df, overall_position_summary, summary_path, plot_path

--- a/ml4h/recipes.py
+++ b/ml4h/recipes.py
@@ -1208,17 +1208,23 @@ def infer_transformer_on_parquet(args):
     keras.config.enable_unsafe_deserialization()
     pre_model = keras.models.load_model(args.model_file)
 
-    info = extract_build_args_from_transformer_model(pre_model)
-    
-    builder_type = info["builder_type"]
-    build_args = info["build_args"]
+    if args.inspect_model:
+        # Rebuild the architecture from the loaded model so we also get model_explain,
+        # which the rollout/relevance code below needs.
+        info = extract_build_args_from_transformer_model(pre_model)
 
-    if builder_type == "embedding_transformer":
-        model, model_explain = build_embedding_transformer(**build_args)
+        builder_type = info["builder_type"]
+        build_args = info["build_args"]
+
+        if builder_type == "embedding_transformer":
+            model, model_explain = build_embedding_transformer(**build_args)
+        else:
+            model, model_explain = build_general_embedding_transformer(**build_args)
+
+        model.set_weights(pre_model.get_weights())
     else:
-        model, model_explain = build_general_embedding_transformer(**build_args)
-    
-    model.set_weights(pre_model.get_weights())
+        model = pre_model
+        model_explain = None
 
     # Get target columns from model output names
     all_targets = args.target_regression_columns + args.target_binary_columns
@@ -1234,7 +1240,6 @@ def infer_transformer_on_parquet(args):
     df_sorted = df.sort_values([AGGREGATE_COLUMN, sort_column],
                                ascending=[True, sort_column_ascend]).reset_index(drop=True)
 
-    '''
     _, _, test_group_ids = split_group_ids_from_dataframe(
         df_sorted,
         AGGREGATE_COLUMN,
@@ -1242,7 +1247,6 @@ def infer_transformer_on_parquet(args):
         valid_csv=args.valid_csv,
         test_csv=args.test_csv,
     )
-    '''
 
     # Build group index
     group_index = {}
@@ -1252,7 +1256,7 @@ def infer_transformer_on_parquet(args):
         group_index[gid] = (first, last)
 
     # Match the exact evaluation cohort used by training.
-    group_ids = list(group_index.keys())#test_group_ids
+    group_ids = test_group_ids
     logging.info(f"Selected {len(group_ids)} test groups based on shared split logic")
 
     # Limit samples if max_samples is set

--- a/ml4h/recipes.py
+++ b/ml4h/recipes.py
@@ -129,6 +129,11 @@ from ml4h.tensorize.tensor_writer_ukbb import (
     write_tensors_from_ecg_pngs,
 )
 
+from ml4h.models.transformer_interpretability import (
+    extract_build_args_from_transformer_model,
+    plot_average_rollout_importance_from_results_binned
+)
+
 from ml4ht.data.util.date_selector import DATE_OPTION_KEY
 from ml4ht.data.sample_getter import DataDescriptionSampleGetter
 from ml4ht.data.data_loader import SampleGetterIterableDataset, shuffle_get_epoch
@@ -950,7 +955,7 @@ def train_transformer_on_parquet_stream(args):
         keras.config.enable_unsafe_deserialization()
         model = keras.models.load_model(args.model_file)
     else:
-        model = build_general_embedding_transformer(
+        model, _ = build_general_embedding_transformer(
             latent_dim=args.latent_dimensions,
             numeric_columns=args.input_numeric_columns,
             categorical_columns=args.input_categorical_columns,
@@ -1080,7 +1085,7 @@ def train_transformer_on_parquet(args):
         keras.config.enable_unsafe_deserialization()
         model = keras.models.load_model(args.model_file)
     else:
-        model = build_embedding_transformer(
+        model, _ = build_embedding_transformer(
             input_numeric_cols=input_numeric_columns,
             regression_targets=args.target_regression_columns,
             binary_targets=args.target_binary_columns,
@@ -1187,7 +1192,7 @@ def infer_transformer_on_parquet(args):
     # Build input columns (same as training)
     input_numeric_columns = args.input_numeric_columns
     input_numeric_columns += [f'latent_{i}' for i in range(args.latent_dimensions_start, args.latent_dimensions + args.latent_dimensions_start)]
-
+    
     # Handle categorical column
     if len(args.input_categorical_columns) == 1:
         input_categorical_column = args.input_categorical_columns[0]
@@ -1201,7 +1206,19 @@ def infer_transformer_on_parquet(args):
     # Load the trained model
     logging.info(f"Loading model from {args.model_file}")
     keras.config.enable_unsafe_deserialization()
-    model = keras.models.load_model(args.model_file)
+    pre_model = keras.models.load_model(args.model_file)
+
+    info = extract_build_args_from_transformer_model(pre_model)
+    
+    builder_type = info["builder_type"]
+    build_args = info["build_args"]
+
+    if builder_type == "embedding_transformer":
+        model, model_explain = build_embedding_transformer(**build_args)
+    else:
+        model, model_explain = build_general_embedding_transformer(**build_args)
+    
+    model.set_weights(pre_model.get_weights())
 
     # Get target columns from model output names
     all_targets = args.target_regression_columns + args.target_binary_columns
@@ -1217,6 +1234,7 @@ def infer_transformer_on_parquet(args):
     df_sorted = df.sort_values([AGGREGATE_COLUMN, sort_column],
                                ascending=[True, sort_column_ascend]).reset_index(drop=True)
 
+    '''
     _, _, test_group_ids = split_group_ids_from_dataframe(
         df_sorted,
         AGGREGATE_COLUMN,
@@ -1224,6 +1242,7 @@ def infer_transformer_on_parquet(args):
         valid_csv=args.valid_csv,
         test_csv=args.test_csv,
     )
+    '''
 
     # Build group index
     group_index = {}
@@ -1233,7 +1252,7 @@ def infer_transformer_on_parquet(args):
         group_index[gid] = (first, last)
 
     # Match the exact evaluation cohort used by training.
-    group_ids = test_group_ids
+    group_ids = list(group_index.keys())#test_group_ids
     logging.info(f"Selected {len(group_ids)} test groups based on shared split logic")
 
     # Limit samples if max_samples is set
@@ -1262,9 +1281,11 @@ def infer_transformer_on_parquet(args):
     for t in all_targets:
         results[f'{t}_prediction'] = []
         results[t] = []
+        if args.inspect_model:
+            results[f'{t}_relevance'] = []
 
     Feat = len(input_numeric_columns)
-
+    
     # Process each group
     logging.info(f"Starting inference over {len(group_ids)} groups...")
     for i, gid in enumerate(group_ids):
@@ -1319,6 +1340,27 @@ def infer_transformer_on_parquet(args):
         # Run inference
         outputs = model(inputs, training=False)
 
+        if args.inspect_model:
+            from ml4h.models.transformer_interpretability import grad_weighted_attention_rollout
+
+            relevance_by_target = {}
+            for t in all_targets:
+                relevance, rollout, outputs_np, layer_debug_df, layer_mats = (
+                    grad_weighted_attention_rollout(
+                        explainable_model=model_explain,   # the second return of build_embedding_transformer
+                        batch_inputs=inputs,               # full dict: num/mask (+ view if categorical)
+                        actual_len=T,                      # number of valid (non-padded) tokens
+                        n_layers=None,                     # None → auto-detect all mha_*_scores layers
+                        target_key=t,                      # binary/regression head name
+                        residual_weight=0.5,
+                        attention_weight=0.5,
+                        use_abs_grad=True,
+                        positive_only=False,
+                    )
+                )
+
+                relevance_by_target[t] = relevance
+
         # Store results
         results['mrn'].append(gid)
         results[sort_column].append(arr_sort_col[start])  # First/top entry's sort column value
@@ -1328,6 +1370,11 @@ def infer_transformer_on_parquet(args):
             # Get prediction (flatten from (1, 1) to scalar)
             pred = outputs[t].numpy().flatten()[0]
             results[f'{t}_prediction'].append(float(pred))
+
+            if args.inspect_model:
+                results[f'{t}_relevance'].append(
+                    relevance_by_target[t].astype(float).tolist()
+                )
 
             # Get true label (max per group)
             if arr_tgts[t] is not None:
@@ -1340,6 +1387,19 @@ def infer_transformer_on_parquet(args):
 
     # Create output dataframe
     output_df = pd.DataFrame(results)
+
+    if args.inspect_model:
+        for t in all_targets:
+            _, summary_df, summary_path, plot_path = plot_average_rollout_importance_from_results_binned(
+                results=results,
+                target=t,
+                output_folder=f"{args.output_folder}/{args.id}",
+                run_id=args.id,
+                n_position_bins=10,
+            )
+
+        logging.info(f"Saved rollout summary for {t} to {summary_path}")
+        logging.info(f"Saved rollout plot for {t} to {plot_path}")
 
     # Calculate and report performance metrics before saving
     logging.info(f"\n=== Performance Metrics ===")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -72,6 +72,7 @@ class TestRecipes:
             test_steps=10,
             output_folder=str(tmp_path),
             id='fast_infer_test',
+            inspect_model=False,
         )
 
         infer_transformer_on_parquet(args)

--- a/tests/test_transformer_builders.py
+++ b/tests/test_transformer_builders.py
@@ -99,11 +99,11 @@ def test_build_embedding_transformer_positional_embedding_toggle():
     )
 
     with _cpu_device():
-        model_with_pos = build_embedding_transformer(
+        model_with_pos, _ = build_embedding_transformer(
             **params,
             use_positional_embedding=True,
         )
-        model_without_pos = build_embedding_transformer(
+        model_without_pos, _ = build_embedding_transformer(
             **params,
         )
 
@@ -157,7 +157,7 @@ def test_build_general_embedding_transformer_learns_easy_tasks(use_categorical, 
     }
 
     with _cpu_device():
-        model = build_general_embedding_transformer(
+        model, _ = build_general_embedding_transformer(
             latent_dim=latent_dim,
             numeric_columns=numeric_columns,
             categorical_columns=categorical_columns,
@@ -208,7 +208,6 @@ def test_build_embedding_transformer_learns_easy_tasks(capsys):
     num_samples = 32
     max_len = 4
     num_features = 64
-    view2id = {"apical": 1, "parasternal": 2}
 
     num = np.zeros((num_samples, max_len, num_features), dtype=np.float32)
     signal = np.linspace(-1.0, 1.0, num_samples, dtype=np.float32)
@@ -217,8 +216,6 @@ def test_build_embedding_transformer_learns_easy_tasks(capsys):
     num[:, :, 2] = 1.0
 
     mask = np.ones((num_samples, max_len), dtype=bool)
-    view = np.where(signal > 0, 2, 1).astype(np.int32)
-    view = np.tile(view[:, None], (1, max_len))
 
     regression_target = (1.5 * signal + 0.25).astype(np.float32)
     binary_target = (signal > 0).astype(np.float32)
@@ -226,7 +223,6 @@ def test_build_embedding_transformer_learns_easy_tasks(capsys):
     inputs = {
         "num": num,
         "mask": mask,
-        "view": view,
     }
     outputs = {
         "regression_task": regression_target[:, None],
@@ -234,7 +230,7 @@ def test_build_embedding_transformer_learns_easy_tasks(capsys):
     }
 
     with _cpu_device():
-        model = build_embedding_transformer(
+        model, _ = build_embedding_transformer(
             input_numeric_cols=[f"feature_{i}" for i in range(num_features)],
             regression_targets=["regression_task"],
             binary_targets=["binary_task"],
@@ -245,7 +241,7 @@ def test_build_embedding_transformer_learns_easy_tasks(capsys):
             num_heads=2,
             num_layers=1,
             dropout=0.0,
-            view2id=view2id,
+            view2id=None,
             learning_rate=1e-3,
         )
         model = _recompile_for_fair_test(model)


### PR DESCRIPTION
Chefer Rollout is a transformer interpretion method published in CVPR 2021. We implemented a modified version for our usecase.